### PR TITLE
Add dispersion metric quantiles

### DIFF
--- a/src/BayesianSafetyValidation.jl
+++ b/src/BayesianSafetyValidation.jl
@@ -88,6 +88,7 @@ export
     most_likely_failures,
     most_likely_failure_likelihood,
     coverage,
+    quantile_coverage,
     region_characterization,
     compute_metrics,
 


### PR DESCRIPTION
Add `qunatile_coverage`, to enable additional coverage metrics beyond the average coverage.  This gives us a more granular view of the coverage, which will be important for certification.

For example, we may want to look at the 20th percentile of the grid coverage to make sure that it is still sufficiently high.  In the case of the dummy squares system with `T=100` samples, this comes out to .038, meaning that 20% of grid points have no sample point within ~96% of the size of a grid square.  Note that this metric is fairly sensitive to the granularity of the grid (i.e. the `num_steps` parameter).  For comparison, the average coverage in this scenario is .37